### PR TITLE
prevent crash due to multicraft bug

### DIFF
--- a/notify.lua
+++ b/notify.lua
@@ -1,6 +1,8 @@
 local mod_name = minetest.get_current_modname()
 local hud_name = ("%s_feedback"):format(mod_name)
 
+local is_multicraft = minetest.get_version().project == "MultiCraft"
+
 local hud_info_by_player_name = {}
 local hud_timeout_seconds = 3
 
@@ -45,7 +47,10 @@ local function hud_update(player, player_name, hud_id, message, params)
 	local def = get_hud_def(message, params)
 
 	for key, value in pairs(def) do
-		player:hud_change(hud_id, key, value)
+		-- multicraft has a bug that requires the "value" argument of hud_change to be a number
+		if not is_multicraft or type(value) == "number" then
+			player:hud_change(hud_id, key, value)
+		end
 	end
 
 	hud_info_by_player_name[player_name] = {


### PR DESCRIPTION
For some reason, multicraft only allows updating hud values which are represented by a number. This fix checks for the presence of multicraft to avoid crashing it when players do something that updates the rhotator hud. 

Fixes  #5.