### PR TITLE
fix is_valid_player

### DIFF
--- a/notify.lua
+++ b/notify.lua
@@ -89,12 +89,9 @@ end
 notify.error = notify.err
 
 local function is_valid_player(player)
-	return player
-		and player.get_player_name
-		and player.hud_get
-		and player.hud_add
-		and player.hud_change
-		and player.hud_remove
+	return type(player) == "userdata"   -- make sure it is the builtin player
+	    and type(player.is_player) == "function"
+		and player:is_player()
 end
 
 notify.__call = function(self, player, message, params)


### PR DESCRIPTION
the current implementation of 
https://github.com/entuland/rhotator/blob/0b4a320cb48d9d1c07eac2459f0927b6b11e2e0e/notify.lua#L91-L98
cannot detect the fakeplayer from fakelib (previous pipeworks). This is bc. the fakeplayer object implements dummy functions for everything. These funcs all do nothing and return nil. 
- fakeplayers `hud_add` returning nil is the reason for `hud_info.id` becoming nil. (I guess that's also the reason for all the crashes). afaik the crashes are all fixed with the last nil check. 
- fakeplayers `hud_remove` doing nothing leads to rhotator assuming the hud from the real player is gone while it is not. So the hud message will stay forever on the screen

I mean: this is really not your fault, but pipeworks/fakelib forces us to check for their fakeplayer everywhere :-/
feel free to ask if my explanation is too confusing.